### PR TITLE
fix the bug in changing dark mode to light mode

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -318,7 +318,8 @@ h1, h2, h3, h4, h5, h6 {
     margin-bottom: auto;
     color: var(--apppimage);
     box-shadow: rgba(0, 0, 0, 0.3) 0px 19px 38px, rgba(0, 0, 0, 0.22) 0px 15px 12px;
-    background-color: #26282b;
+    /* because of this it is of black color now it will inherit the body color */
+    /* background-color: #26282b; */
     border-bottom-right-radius: 35px;
     border-top-left-radius: 35px;
     transition: all 0.2s;


### PR DESCRIPTION
## Related Issuse

There was a small bug when user change the light mode from dark mode as shown in below image.
<img width="960" alt="prob1" src="https://user-images.githubusercontent.com/55352601/111877664-493bff80-89ca-11eb-9fed-7d2e7adfa833.png">


Closes: #[285]

#### Describe the changes you've made

I had just remove the hard coded background-color of the required area because of which now it will take the color of body automatically , if it is in light mode it will of light color , if it is dark mode it will of dark color
<img width="960" alt="prob2" src="https://user-images.githubusercontent.com/55352601/111877750-acc62d00-89ca-11eb-9120-8e30948b4d25.png">

## Checklist:

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.

## Screenshots

|        Original         |          Updated           |
| :---------------------: | :------------------------: |
| **original screenshot** | <b>updated screenshot </b> |
