### PR TITLE
Fixed calculator operators bug

### DIFF
--- a/css/simplecal.css
+++ b/css/simplecal.css
@@ -110,6 +110,11 @@
     border-radius: 0 0 0 40px;
 }
 
+.divi img, .sub img, .mul img, .plus img, #slogo{
+    filter:brightness(100%);
+    height: 1.2em;
+    width:1em;
+}
 
 .light-mode .calculator span
 {
@@ -125,13 +130,13 @@
 /* --------------------Responsive calculator-------------------- */
 @media (max-width: 450px) {
   .calculator span {
-
-    font-size: 15px;
+    font-size: 19px;
     height:auto;
-    width:auto;
+    width: 3.5em;
   }
   .calculator span.clear {
     width: auto;
+    height: 3.2em;
   }
   .calculator span.back {
     width: auto;


### PR DESCRIPTION
## Related Issuse

- Info about Issue or bug
Some operators were not visible on the calculator and of black color now they are properly visible also modified a little css of responsive calculator to make it look good.

Closes: #300 

#### Describe the changes you've made

A clear and concise description of what you have done to successfully close your assigned issue. Any new files? or anything you feel to let us know!

## Checklist:

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.

## Screenshots

|        Original         |          Updated           |
| :---------------------: | :------------------------: |
| **   
![mathissue5](https://user-images.githubusercontent.com/61223163/111906528-eb192600-8a76-11eb-8dc4-de83b48709fd.PNG)
** | <b></b> |
![mathissue5solved](https://user-images.githubusercontent.com/61223163/111906544-f9674200-8a76-11eb-9fe2-aadf96b34262.PNG)

