### PR TITLE
Fixed Issue number #306 (Copyright section should not hover)

### DIFF
--- a/index.html
+++ b/index.html
@@ -764,7 +764,7 @@
                         </td>
                     </tr>
                 </table>
-            </li>            
+            </li>
 
             <div class="dropdown-divider"></div>
         </div>
@@ -1156,8 +1156,7 @@
                                        style="cursor: pointer;color:var(--appimage);font-size: 1rem;"
                                        onclick="myFunction()">Change Mode
             <span id="moon" style="font-size: 1.25rem;">🌓</span></a></li>
-        <li class="list_menu_items"
-            style="color:var(--appimage);font-size: 0.5rem; bottom: 0rem; position:relative;">Copyright © 2021 Makes
+        <li style="color:var(--appimage);font-size: 0.5rem; bottom: 0rem; position:relative;">Copyright © 2021 Makes
             Math Easy. All Rights Reserved.
         </li>
     </ul>
@@ -2962,11 +2961,11 @@
                 <p>Kindly press the button twice for re-entering the angle</p>
 
             </div>
-            
+
             <div class="form-group">
                 <canvas id="plotangleres" width="1000" height="500" style="border:1px solid #d3d3d3;background-color:white">
               </canvas>
-                
+
             </div>
         </div>
 
@@ -3240,7 +3239,7 @@
         <!--sum of nterms in A.P. ends-->
 
         <!-- sum of nterms in G.P.  -->
-        <div class="collapse" id="sum_n_GP">            
+        <div class="collapse" id="sum_n_GP">
             <h2>Sum of Nterms of an Geometric Progression</h2>
             <div class="form-group">
                 <input type="text" style="width: 15.625rem;" class="form__field"  id="firstterm"
@@ -3253,7 +3252,7 @@
                 <br>
                 <button class="btn btn-outline-light" onclick="gp()">Find</button>
                 <br>
-                <div style="color:var(--appimage); font-size: large;" id="sumgp"></div>                
+                <div style="color:var(--appimage); font-size: large;" id="sumgp"></div>
             </div>
         </div>
         <!-- sum of nterms in G.P. ends  -->


### PR DESCRIPTION
- Info about Issue or bug
Copyright section should not hover.

Closes: #[issue number that will be closed through this PR]
Issue Number #306 

#### Describe the changes you've made
I have removed class in copyright section which was targeting for hover.

## Checklist:

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Screenshots

|        Original         |          Updated           |
| :---------------------: | :------------------------: |
| **original screenshot** | <b>updated screenshot </b> |
![image](https://user-images.githubusercontent.com/67696867/111909584-e018c280-8a83-11eb-9c7f-6f725dc197d2.png)
![image](https://user-images.githubusercontent.com/67696867/111909603-f6268300-8a83-11eb-808b-24e8fb0d5081.png)

