### PR TITLE
Fixed the bug in median calculator for odd sized data

### DIFF
--- a/appjs/logicjavascript.js
+++ b/appjs/logicjavascript.js
@@ -3905,7 +3905,7 @@ function Median() {
     let median =
       len % 2 === 0
         ? (parseInt(arr[mid]) + parseInt(arr[mid - 1])) / 2
-        : arr[mid - 1];
+        : arr[mid];
     document.getElementById(
       "Meanresult"
     ).innerHTML = `After Sorting:- ${arr}</br>`;


### PR DESCRIPTION
## Related Issuse

#397

Closes: #[issue number that will be closed through this PR]
#397
#### Describe the changes you've made
Edited the median function so that it shows right output for odd sized data.
## Checklist:

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.

![Screenshot (152)](https://user-images.githubusercontent.com/66053534/112264715-4a558100-8c97-11eb-88dc-0a6a34681255.png)
![Screenshot (153)](https://user-images.githubusercontent.com/66053534/112264721-4c1f4480-8c97-11eb-9972-3051c0e739b5.png)
