### PR TITLE
Solved issue #408

### DIFF
--- a/index.html
+++ b/index.html
@@ -3392,7 +3392,7 @@
                                     </button>
                                 </div>
                                 <div class="modal-body">
-                                    <p>There are no Real Roots if \[b^2-4ac<0\]< /p>
+                                    <p>There are no Real Roots if \[b^2-4ac<0\]</p>
                                     <p>There is one Real Root if \[b^2-4ac=0\]</p>
                                     <p>There are two Real Roots if \[b^2-4ac>0\]</p>
                                 </div>


### PR DESCRIPTION
## Related Issuse

Html tag is no more visible in Rules for Roots of Quadratic Equation

Closes: #408 

#### Describe the changes you've made

A clear and concise description of what you have done to successfully close your assigned issue. Any new files? or anything you feel to let us know!

## Checklist:

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.

## Screenshots

|        Original         |          Updated           |
| :---------------------: | :------------------------: |
| **original screenshot** | ![image](https://user-images.githubusercontent.com/71064674/112342561-54ec3680-8ce8-11eb-945c-280141e8e19a.png)
 |
