### PR TITLE
Fixed bug in Logarithm Calculator

### DIFF
--- a/appjs/working.js
+++ b/appjs/working.js
@@ -34,8 +34,12 @@ $(document).ready(function () {
          openit("#fractions");
          closenav();
          clearall();
-     })
-
+     });
+    $("#logValues").click(function(){
+        openit("#log_values");
+        closenav();
+        clearall();
+    });
     $("#aboutbutton").click(function () {
         openit("#about");
         closenav();


### PR DESCRIPTION
## Related Issuse

After clicking in logarithm calculator , the nav bar isnt getting closed on its own while it gets closed on its own when we click on other other calculators

Closes: #406

#### Describe the changes you've made
I added the missing code i.e, 
$("#logValues").click(function(){
        openit("#log_values");
        closenav();
        clearall();
    });
## Checklist:

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.

 