### PR TITLE
RECTIFIED - Simple interest and compound interest input and output error

### DIFF
--- a/appjs/logicjavascript.js
+++ b/appjs/logicjavascript.js
@@ -3757,11 +3757,27 @@ function simple_interest() {
     p = document.getElementById("first").value;
     t = document.getElementById("second").value;
     r = document.getElementById("third").value;
-    si = parseFloat((p * t * r) / 100).toFixed(3);
-    amount = p * Math.pow(1 + r / 100, t);
-    ci = amount - p;
-    document.getElementById("simpleinterstoutput").innerHTML = "Simple interest = ₹" + si;
-    document.getElementById("compoundinterestoutput").innerHTML = "Compound interest = ₹" + ci;
+    if(p=="" || t=="" || r=="")
+    {
+        document.getElementById("simpleinterstoutput").innerHTML = "All the fields are required";
+        document.getElementById("compoundinterestoutput").innerHTML = "";
+    }
+    else
+    {
+        si = parseFloat((p * t * r) / 100).toFixed(3);
+        if(si<0)
+        {
+            document.getElementById("simpleinterstoutput").innerHTML = "Negative values not allowed";
+            document.getElementById("compoundinterestoutput").innerHTML = "";
+        }
+        else
+        {
+            amount = p * Math.pow(1 + r / 100, t);
+            ci = amount - p;
+            document.getElementById("simpleinterstoutput").innerHTML = "Simple interest = ₹" + si;
+            document.getElementById("compoundinterestoutput").innerHTML = "Compound interest = ₹" + ci;
+        }
+    }
 }
 
 // EMI Calulator

--- a/index.html
+++ b/index.html
@@ -10257,7 +10257,7 @@
 
                     <div class="col-6">
                         <label for="from">
-                            <h5 class="text-center" style="">From</h5>
+                            <h5 class="text-center">From</h5>
                         </label>
                         <select id="datacon-1" class="form__field" onchange="datacon()">
                             <option value="1" class="form_field"
@@ -10287,7 +10287,7 @@
                                oninput="datacon();">
 
                         <label for="To">
-                            <h5 class="text-center" style="">To</h5>
+                            <h5 class="text-center">To</h5>
                         </label>
                         <select id="datacon-2" class="form__field" onchange="datacon()">
                             <option value="1" class="form_field"


### PR DESCRIPTION
## Related Issuse

- Simple interest and compound interest calculator was functioning over negative values and blank inputs which was required to be restricted since money amount, time and interest rate can't be negative.

Closes: #589 

#### Describe the changes you've made

I have put up proper values checks for taking correct input and making sure no input field is left empty.

## Checklist:

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.

## Screenshots

|        Original         |          Updated           |
| :---------------------: | :------------------------: |
| **original screenshot** | <b>updated screenshot </b> |
![Attention - Simple interest and compound interest negative values](https://user-images.githubusercontent.com/55992140/112871111-8b58f580-90dc-11eb-8c90-befa104a384c.PNG)| ![RECTIFIED - CI and SI 1](https://user-images.githubusercontent.com/55992140/112870747-230a1400-90dc-11eb-8be7-f78c46474caa.PNG)
![Attention - CI and SI compounded](https://user-images.githubusercontent.com/55992140/112870366-c0b11380-90db-11eb-909d-5d8354e77bde.PNG)|![RECTIFIED - CI and SI 2](https://user-images.githubusercontent.com/55992140/112870752-243b4100-90dc-11eb-9c62-ca544a181046.PNG)
