### PR TITLE
Addition of fraction bug rectified

### DIFF
--- a/appjs/operations_on_fraction.js
+++ b/appjs/operations_on_fraction.js
@@ -27,7 +27,7 @@ function display_fractions(){
     document.getElementById('d1').innerHTML = d2;
     document.getElementById('b2').innerHTML = d1;
     document.getElementById('d2').innerHTML = d2;
-    document.getElementById('e').innerHTML = n1*d2;
+    document.getElementById('e1').innerHTML = n1*d2;
     document.getElementById('g').innerHTML = n2*d1;
     document.getElementById('f').innerHTML = d1*d2;
     var top = (n1*d2) +(n2*d1);

--- a/index.html
+++ b/index.html
@@ -9246,7 +9246,7 @@
                                 <span class="symbol">/</span>
                                 <span class="bottom"><var id="b2">b</var>*<var id="d2">d</var></span>
 
-                                <span>= &nbsp;<var id="e">e</var>+<var id="g">g</var></span>
+                                <span>= &nbsp;<var id="e1">e</var>+<var id="g">g</var></span>
                                 <span class="symbol">/</span>
                                 <span class="bottom"><var id="f">f</var></span>
 


### PR DESCRIPTION
## Related Issuse

-In explanation of addition of two fractions , 'e' was not replaced by its value

Closes: #[848]

#### Describe the changes you've made
I have just changed the id of that element because that id already exits with some other element


## Screenshots

|        Original         |  

![addition](https://user-images.githubusercontent.com/75009990/113827200-a4c70500-97a0-11eb-89d7-d35b707beaff.png)
|        [Updated]      |
![UPDATED](https://user-images.githubusercontent.com/75009990/113827484-fc657080-97a0-11eb-962d-6ee96ebb66a6.png)

