### PR TITLE
Added T-Ratios for many angles in sequence

### DIFF
--- a/index.html
+++ b/index.html
@@ -5879,24 +5879,49 @@
                     </tr>
                     </tbody>
                 </table>
-                <h2>\[Values \space of \space some \space T-Ratios \space for \space Angles
-                    \space 18^{\circ} , \space 36^{\circ} , \space 15^{\circ}, \space
-                    22.5^{\circ} , \space 67.5^{\circ}\]</h2>
-                <p>\[1) \space sin18^{\circ}= \frac{\sqrt{5}-1}{4}= cos72^{\circ}= sin
-                    \frac{\pi}{10} \]</p>
-                <p>\[2) \space cos36^{\circ}= \frac{\sqrt{5}+1}{4}= cos54^{\circ}=cos
+                <h2>\[Values \space of \space some \space T-Ratios \space for \space many \space angles \]</h2>
+                <p>\[1) \space sin(7.5^{\circ})= \frac{\sqrt{2-\sqrt{2+\sqrt{3}}}}{2}= cos(82.5^{\circ})= sin
+                    \frac{\pi}{24}\]</p>
+                <p>\[2) \space cos(7.5^{\circ})= \frac{\sqrt{2+\sqrt{2+\sqrt{3}}}}{2}= sin(82.5^{\circ})= cos
+                    \frac{\pi}{24}\]</p>
+                <p>\[3) \space tan(7.5^{\circ})= \sqrt{6}-\sqrt{3}+\sqrt{2}-2=(\sqrt{2}-1)(\sqrt{3}-\sqrt{2})= 
+                    cot(82.5^{\circ})= tan\frac{\pi}{24}\]</p>
+                <p>\[4) \space cot(7.5^{\circ})= \sqrt{6}+\sqrt{3}+\sqrt{2}+2=(\sqrt{2}+1)(\sqrt{3}+\sqrt{2})= 
+                    tan(82.5^{\circ})= cot\frac{\pi}{24}\]</p>
+                <p>\[5) \space sin15^{\circ}= \frac{\sqrt{3}-1}{2\sqrt{2}}= cos75^{\circ}= sin
+                    \frac{\pi}{12}\]</p>
+                <p>\[6) \space cos15^{\circ}= \frac{\sqrt{3}+1}{2\sqrt{2}}= sin75^{\circ}= cos
+                    \frac{\pi}{12}\]</p>
+                <p>\[7) \space tan15^{\circ}= 2-\sqrt{3}= cot75^{\circ}= tan\frac{\pi}{12}\]</p>
+                <p>\[8) \space cot15^{\circ}= 2+\sqrt{3}= tan75^{\circ}= cot\frac{\pi}{12}\]</p>
+                <p>\[9) \space sin18^{\circ}= \frac{\sqrt{5}-1}{4}= \sqrt{\frac{3-\sqrt{5}}{8}}
+                    = cos72^{\circ}= sin\frac{\pi}{10} \]</p>
+                <p>\[10) \space cos18^{\circ}= \frac{\sqrt{10+2\sqrt{5}}}{4}= \sqrt{\frac{5+\sqrt{5}}{8}}
+                    = sin72^{\circ}= cos\frac{\pi}{10} \]</p>
+                <p>\[11) \space tan18^{\circ}= \sqrt{1-\frac{2\sqrt{5}}{5}}= cot72^{\circ}= tan\frac{\pi}{10}\]</p>
+                <p>\[12) \space cot18^{\circ}= \sqrt{5+2\sqrt{5}}= tan72^{\circ}= cot\frac{\pi}{10}\]</p>
+                <p>\[13) \space sin(22.5^{\circ})= \frac{\sqrt{2-\sqrt{2}}}{2}= \sqrt{\frac{4-\sqrt{8}}{8}}
+                    = cos(67.5^{\circ})= sin\frac{\pi}{8}\]</p>
+                <p>\[14) \space cos(22.5^{\circ})= \frac{\sqrt{2+\sqrt{2}}}{2}= \sqrt{\frac{4+\sqrt{8}}{8}}
+                    = sin(67.5^{\circ})= cos\frac{\pi}{8}\]</p>
+                <p>\[15) \space tan(22.5^{\circ})=\sqrt{2}-1=cot(67.5^{\circ})= tan\frac{\pi}{8}\]</p>
+                <p>\[16) \space cot(22.5^{\circ})=1+\sqrt{2}=tan(67.5^{\circ})= cot\frac{\pi}{8}\]</p>
+                <p>\[17) \space sin36^{\circ}= \frac{\sqrt{10-2\sqrt{5}}}{4}= \sqrt{\frac{5-\sqrt{5}}{8}}=
+                    cos54^{\circ}= sin\frac{\pi}{5}\]</p>
+                <p>\[18) \space cos36^{\circ}= \frac{\sqrt{5}+1}{4}= \sqrt{\frac{3+\sqrt{5}}{8}}= sin54^{\circ}=cos
                     \frac{\pi}{5}\]</p>
-                <p>\[3) \space sin15^{\circ}= \frac{\sqrt{3}-1}{2\sqrt{2}}= cos75^{\circ}=sin
-                    \frac{\pi}{12}\]</p>
-                <p>\[4) \space cos15^{\circ}= \frac{\sqrt{3}+1}{2\sqrt{2}}= sin75^{\circ}=cos
-                    \frac{\pi}{12}\]</p>
-                <p>\[5) \space
-                    tan\frac{\pi}{12}=2-\sqrt{3}=\frac{\sqrt{3}-1}{\sqrt{3}+1}=cot\frac{5\pi}{12}\]</p>
-                <p>\[6) \space
-                    tan\frac{5\pi}{12}=2+\sqrt{3}=\frac{\sqrt{3}+1}{\sqrt{3}-1}=cot\frac{\pi}{12}\]</p>
-                <p>\[7) \space
-                    tan(22.5^{\circ})=\sqrt{2}-1=cot(67.5^{\circ})=cot\frac{3\pi}{8}=tan\frac{\pi}{8}\]</p>
-                <p>\[8) \space tan(67.5^{\circ})=\sqrt{2}+1=cot(22.5^{\circ})\]
+                <p>\[19) \space tan36^{\circ}= \sqrt{5-2\sqrt{5}}= cot54^{\circ}= tan
+                    \frac{\pi}{5}\]</p>
+                <p>\[20) \space cot36^{\circ}= \sqrt{\frac{5+2\sqrt{5}}{5}}= tan54^{\circ}= cot
+                    \frac{\pi}{5}\]</p>
+                <p>\[21) \space sin(37.5^{\circ})= \frac{\sqrt{2-\sqrt{2-\sqrt{3}}}}{2}= cos(52.5^{\circ})= sin
+                    \frac{5\pi}{24}\]</p>
+                <p>\[22) \space cos(37.5^{\circ})= \frac{\sqrt{2+\sqrt{2-\sqrt{3}}}}{2}= sin(52.5^{\circ})= cos
+                    \frac{5\pi}{24}\]</p>
+                <p>\[23) \space tan(37.5^{\circ})= \sqrt{6}+\sqrt{3}-\sqrt{2}-2=(\sqrt{2}+1)(\sqrt{3}-\sqrt{2})= 
+                    cot(52.5^{\circ})= tan\frac{5\pi}{24}\]</p>
+                <p>\[24) \space cot(37.5^{\circ})= \sqrt{6}-\sqrt{3}-\sqrt{2}+2=(\sqrt{2}-1)(\sqrt{3}+\sqrt{2})= 
+                    tan(52.5^{\circ})= cot\frac{5\pi}{24} \]</p>
             </div>
         </div>
 


### PR DESCRIPTION
## Related Issue:

- The values of trigonometric ratios were not well organized and also some values of some functions were missing too!
- Degrees are not in one particular order, it's like 18,36,15...
So how one can check the list if it's not ordered in any manner (i.e. ascending or descending)?
Earlier, it was not in one format like while writing first equation it was having `sin` to `cos`,in another one it was  `cos` to `cos`,etc. and messing up all.


Closes: #850 

#### Describe the changes you've made

- I have added values of T-Ratios for many angles in sequence.
- Written it in particular manner so that the process of searching can be easily done.
- I have made equations in one standard format, so one don't get confused while taking an overview.

## Checklist:

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.

## Screenshots

|        Original         |          Updated           |
| :---------------------: | :------------------------: |
| **original screenshot** | **updated screenshot** |
| ![values](https://user-images.githubusercontent.com/73488906/113898323-643fa980-97e9-11eb-8610-2f9e7a4d8b55.png) | ![trigo](https://user-images.githubusercontent.com/73488906/113898739-c6001380-97e9-11eb-810d-1bcda8c16a66.png) |
