### PR TITLE
Bug resolved in pentagonal prism calculator

### DIFF
--- a/appjs/logicjavascript.js
+++ b/appjs/logicjavascript.js
@@ -2596,7 +2596,7 @@ function pentprismsolve() {
         voloutput.innerHTML = voltemp;
         tsatemp += "\\[" + 5 + "\\times" + edge + "\\times" + height + "+" + "\\frac{1}{2}" + "\\times" + "\\sqrt" + "(" + 5 + "(" + 5 + "+" + 2 + "\\times" + "\\sqrt" + 5 + ")" + ")" + "\\times" + edge + "\\times" + edge   + "\\]";
         tsatemp += "\\[Surface \\space area \\space of \\space Pentagonal \\space Prism \\space is \\space  \\]";
-        tsatemp += "\\[" + eval(String((5 * edge *height) + (1.72 * edge * edge* height) )) + "\\]";
+        tsatemp += "\\[" + eval(String((5 * edge *height) + (3.44 * edge * edge) )) + "\\]";
         tsaoutput.innerHTML = tsatemp;
         renderMathInElement(voloutput);
         renderMathInElement(tsaoutput);


### PR DESCRIPTION
## Related Issue

- The answer of surface area of pentagonal prism was incorrect.

For example: a = 2, h = 5
The correct answer is 63.76 and above it is displayed 84.4.

Closes: #1086 

#### Describe the changes you've made

I have resolved this calculator error.

## Checklist:

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Screenshots

|        Original         |          Updated           |
| :---------------------: | :------------------------: |
| **original screenshot** | <b>updated screenshot </b> |
| ![pentaprism](https://user-images.githubusercontent.com/73488906/114972349-f441bb00-9e9b-11eb-9ec1-e1b246b549ce.png) | ![pentprism](https://user-images.githubusercontent.com/73488906/114972444-2521f000-9e9c-11eb-9529-3de67a6c5f8d.png) |

