### PR TITLE
Reduced the width of favourite container

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -181,9 +181,10 @@ h6 {
 }
 .favouritecontainer {
   position: absolute;
-  left: 76%;
+  left: 80%;
   right: 0%;
   top: 15%;
+  width: 20%;
   bottom: -0.9375rem;
   background-color: #02050a00;
   padding: 1.25rem;
@@ -242,10 +243,11 @@ h6 {
 }
 @media screen and (max-width: 37.5rem) {
   .favouritecontainer {
-    left: 10%;
+    left: 5%;
     right: 5%;
     top: 15%;
     bottom: -0.9375rem;
+    width: 90%;
     background-color: #232a36ce;
   }
   .favourites {


### PR DESCRIPTION
## Related Issuse

- Favourite lists container was overlapping Number Fact

fix #1371 

#### Describe the changes you've made

Width of favourite lists has been altered keeping the responsive intact.

## Checklist:

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.

## Screenshots

- *updated* 
![Screenshot from 2021-04-24 19-43-32](https://user-images.githubusercontent.com/64921946/115962174-bf86d100-a537-11eb-9244-2a30ecc6ce8d.png)
![Screenshot from 2021-04-24 19-43-54](https://user-images.githubusercontent.com/64921946/115962178-c1e92b00-a537-11eb-9b36-1aab9e5558c1.png)

