### PR TITLE
Slope of line section removed from coordinate geometry calculator

### DIFF
--- a/index.html
+++ b/index.html
@@ -4634,19 +4634,6 @@
                 class="stopwrap"
                align="right"></p>
             <h4 id="ppp_op"> </h4> 
-            <h3>Slope of the line with 2 points known</h3>
-            <p>&nbsp;</p>
-             <div align="center" style="font-family:mathfont;width:auto; color: aliceblue; font-size: 1.5em;">
-            Required Coordinates: <input type="text" id="slx1" size=3 placeholder="X1"> , <input type="text" id="sly1" size=3 placeholder="Y1">  ,
-             <input type="text" id="slx2" size=3 placeholder="X2">  , <input type="text" id="sly2" size=3 placeholder="Y2"> 
-             <br>
-             <br>
-             <button type="button" class="btn btn-light" onclick=slpsolve()>
-                Find Slope Of Line
-            </button>
-            <p>&nbsp;</p>
-            <p id="slpans"></p>
-            </div>
             
         </div>
         <div class="collapse" id="vecalg">


### PR DESCRIPTION
## fix #1725 
I have removed slope of line section from coordinate geometry calculator section because it was working exactly the same way as that in shape section.